### PR TITLE
fix tcp discovery to avoid connecting to speculos twice

### DIFF
--- a/lib/src/transport/mod.rs
+++ b/lib/src/transport/mod.rs
@@ -115,10 +115,9 @@ impl Transport for GenericTransport {
 
         #[cfg(feature = "transport_ble")]
         if filters == Filters::Any || filters == Filters::Ble {
-            // BLE discovery is allowed to fail if not explictly selected
+            // BLE discovery is allowed to fail if not exclusively selected
             // as dbus does not always provide the relevant service (eg. under WSL)
             // TODO: work out whether we can detect this to separate no BLE from discovery failure
-
             match self.ble.list(()).await {
                 Ok(mut d) => devices.append(&mut d),
                 Err(e) if filters == Filters::Any => {

--- a/lib/src/transport/tcp.rs
+++ b/lib/src/transport/tcp.rs
@@ -68,11 +68,11 @@ impl Transport for TcpTransport {
         let mut devices = vec![];
 
         // Check whether a speculos socket is open on the default port
-        let addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 1237);
+        let addr = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 1237);
 
         // We can't -connect- to speculos as this does not handle multiple TCP connections
         // so instead we attempt to bind to the socket we expect speculos to occupy.
-        match TcpListener::bind(addr.clone()).await {
+        match TcpListener::bind(addr).await {
             Ok(_) => (),
             // A failure indicates this is in use and we should report a device available for connection
             Err(_) => {


### PR DESCRIPTION
this precludes future checks for device version (at least via TCP only), but means speculos doesn't route packets incorrectly to the first connection in the case that the host OS does not clean up dropped sockets in a timely manner.

should resolve #1 (@yogh333 could you please test this on the M1?)