### PR TITLE
Add method for launching applications

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,7 +29,7 @@ default = [ "transport_usb", "transport_tcp", "transport_ble", "transport_usb_li
 
 thiserror = "1.0.40"
 encdec = "0.9.0"
-ledger-proto = { version = "0.1.0", features = [ "std" ] }
+ledger-proto = { version = "0.1.0", default_features = false, features = [ "std" ] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 strum = { version = "0.24.1", features = ["derive"] }

--- a/lib/src/device.rs
+++ b/lib/src/device.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use encdec::{EncDec, Encode};
-use tracing::error;
+use tracing::{debug, error};
 
 use ledger_proto::{
     apdus::{AppInfoReq, AppInfoResp, DeviceInfoReq, DeviceInfoResp},
@@ -70,6 +70,8 @@ impl<T: Exchange + Send> Device for T {
         buff: &'b mut [u8],
         timeout: Duration,
     ) -> Result<RESP, Error> {
+        debug!("TX: {req:?}");
+
         // Encode request
         let n = encode_request(req, buff)?;
 
@@ -99,9 +101,10 @@ impl<T: Exchange + Send> Device for T {
             }
         }
 
-        // Decode response
-        // TODO: is it useful to also return the status bytes?
-        let (resp, _) = RESP::decode(&buff[..n])?;
+        // Decode response data - status bytes
+        let (resp, _) = RESP::decode(&buff[..n - 2])?;
+
+        debug!("RX: {resp:?}");
 
         // Return decode response
         Ok(resp)

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -43,11 +43,20 @@ pub enum Error {
     #[error("Request timeout")]
     Timeout,
 
+    #[error("Device or transport closed")]
+    Closed,
+
+    #[error("Empty response payload")]
+    EmptyResponse,
+
     #[error("Unexpected response payload")]
     UnexpectedResponse,
 
     #[error("Device in use")]
     DeviceInUse,
+
+    #[error("Already running application ({0})")]
+    ApplicationLoaded(String),
 }
 
 impl From<tokio::time::error::Elapsed> for Error {

--- a/lib/src/info.rs
+++ b/lib/src/info.rs
@@ -2,6 +2,8 @@
 
 use strum::{Display, EnumString};
 
+use crate::Filters;
+
 use super::transport;
 
 /// Ledger device information
@@ -17,6 +19,20 @@ pub struct LedgerInfo {
 impl std::fmt::Display for LedgerInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{} ({})", self.model, self.conn)
+    }
+}
+
+impl LedgerInfo {
+    /// Fetch connection kind enumeration
+    pub fn kind(&self) -> ConnType {
+        match &self.conn {
+            #[cfg(feature = "transport_usb")]
+            ConnInfo::Usb(_) => ConnType::Usb,
+            #[cfg(feature = "transport_tcp")]
+            ConnInfo::Tcp(_) => ConnType::Tcp,
+            #[cfg(feature = "transport_ble")]
+            ConnInfo::Ble(_) => ConnType::Ble,
+        }
     }
 }
 
@@ -61,6 +77,25 @@ pub enum ConnInfo {
     Tcp(transport::TcpInfo),
     #[cfg(feature = "transport_ble")]
     Ble(transport::BleInfo),
+}
+
+/// Ledger connection types
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum ConnType {
+    Usb,
+    Tcp,
+    Ble,
+}
+
+impl From<ConnType> for Filters {
+    /// Convert a connection type to a discovery filter
+    fn from(value: ConnType) -> Self {
+        match value {
+            ConnType::Usb => Filters::Hid,
+            ConnType::Tcp => Filters::Tcp,
+            ConnType::Ble => Filters::Ble,
+        }
+    }
 }
 
 impl std::fmt::Display for ConnInfo {

--- a/lib/src/transport/usb.rs
+++ b/lib/src/transport/usb.rs
@@ -221,7 +221,10 @@ impl UsbDevice {
         };
 
         // Check read length is valid for following operations
-        if n < 7 {
+        if n == 0 {
+            error!("Empty response");
+            return Err(Error::EmptyResponse);
+        } else if n < 7 {
             error!("Unexpected read length {n}");
             return Err(Error::UnexpectedResponse);
         }

--- a/proto/src/apdus/device_info.rs
+++ b/proto/src/apdus/device_info.rs
@@ -1,3 +1,5 @@
+//! Device information request and response APDUs
+
 use encdec::{Decode, Encode};
 
 use crate::{ApduError, ApduStatic};

--- a/proto/src/apdus/exit_app.rs
+++ b/proto/src/apdus/exit_app.rs
@@ -1,0 +1,25 @@
+//! Exit application APDU
+
+use encdec::{DecodeOwned, Encode};
+
+use crate::{ApduError, ApduStatic};
+
+/// Exit application request APDU, used to exit a running application
+///
+/// Note this is not supported by _all_ applications
+#[derive(Clone, Debug, PartialEq, Default, Encode, DecodeOwned)]
+#[encdec(error = "ApduError")]
+pub struct ExitAppReq {}
+
+/// Set CLA and INS values for [ExitAppReq]
+impl ApduStatic for ExitAppReq {
+    const CLA: u8 = 0xb0;
+    const INS: u8 = 0xa7;
+}
+
+impl ExitAppReq {
+    /// Create a new exit application request
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/proto/src/apdus/mod.rs
+++ b/proto/src/apdus/mod.rs
@@ -5,3 +5,9 @@ pub use app_info::{AppFlags, AppInfoReq, AppInfoResp};
 
 mod device_info;
 pub use device_info::{DeviceInfoReq, DeviceInfoResp};
+
+mod run_app;
+pub use run_app::RunAppReq;
+
+mod exit_app;
+pub use exit_app::ExitAppReq;

--- a/proto/src/apdus/run_app.rs
+++ b/proto/src/apdus/run_app.rs
@@ -1,0 +1,54 @@
+//! Run application APDU
+
+use encdec::{Decode, Encode};
+
+use crate::{ApduError, ApduStatic};
+
+/// Run application request APDU, request to BOLOS to launch an application on the Ledger Device
+#[derive(Clone, Debug, PartialEq, Encode)]
+#[encdec(error = "ApduError")]
+pub struct RunAppReq<'a> {
+    /// Application name to launch (note this is case sensitive)
+    pub app_name: &'a str,
+}
+
+/// Set CLA and INS values for [RunAppReq]
+impl<'a> ApduStatic for RunAppReq<'a> {
+    const CLA: u8 = 0xe0;
+    const INS: u8 = 0xd8;
+}
+
+impl<'a> RunAppReq<'a> {
+    /// Create a new run application request APDU
+    pub fn new(app_name: &'a str) -> Self {
+        Self { app_name }
+    }
+}
+
+impl<'a> Decode<'a> for RunAppReq<'a> {
+    type Output = Self;
+
+    type Error = ApduError;
+
+    fn decode(buff: &'a [u8]) -> Result<(Self::Output, usize), Self::Error> {
+        let app_name = match core::str::from_utf8(buff) {
+            Ok(v) => v,
+            Err(_e) => return Err(ApduError::InvalidUtf8),
+        };
+
+        Ok((Self { app_name }, buff.len()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::RunAppReq;
+
+    #[test]
+    fn encode_decode_run_app_req() {
+        let r = RunAppReq::new("test app");
+
+        let mut buff = [0u8; 256];
+        crate::tests::encode_decode(&mut buff, r);
+    }
+}


### PR DESCRIPTION
Allows higher-level transports to attempt to launch applications on device connection, at the moment this is only usable with USB via the `LedgerProvider` or `GenericTransport` (and tested on MacOS and WSL2).

The implementation is a bit wild because devices re-enumerate when changing apps (and don't report any useful information like a serial number to uniquely identify themselves), with load-bearing delays to allow the OS to drop handles prior to attempting re-connection (otherwise you reconnect to the same now closed device).

I have some tidying up to do yet but, figured it'd be good to open this and see what y'all think (@yhql @yogh333)?