### PR TITLE
add status codes, fix no_std build for ledger-protos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,43 @@ jobs:
         command: clippy
         args: -- -D warnings
 
+  # Check no_std build of protocol objects
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Configure toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          target: thumbv7em-none-eabihf
+
+      - name: Restore shared cache
+        uses: actions/cache/restore@v3
+        with:
+          key: core
+          path: |
+            ~/.cargo
+            ./target
+
+      - name: Check no_std build with alloc
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -p ledger-proto --target=thumbv7em-none-eabihf --no-default-features --features=alloc
+
+      - name: Check no_std build without alloc
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -p ledger-proto --target=thumbv7em-none-eabihf --no-default-features
+
   # Run tests
   test:
     runs-on: ubuntu-latest

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use clap::Parser;
 use hex::ToHex;
-use ledger_proto::{ApduHeader, GenericApdu};
+use ledger_proto::{ApduHeader, GenericApdu, StatusCode};
 use tracing::{debug, error};
 use tracing_subscriber::{filter::LevelFilter, EnvFilter, FmtSubscriber};
 
@@ -178,7 +178,7 @@ async fn main() -> anyhow::Result<()> {
                         Ok(apdu_output) => {
                             println!("Response: {}", apdu_output.data.encode_hex::<String>())
                         }
-                        Err(Error::Response(0x90, 0x00)) => println!("App OK"),
+                        Err(Error::Status(StatusCode::Ok)) => println!("App OK"),
                         Err(e) => println!("Command failed: {e:?}"),
                     }
                 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,6 +38,7 @@ once_cell = "1.17.1"
 uuid = "1.3.2"
 futures = "0.3.28"
 async-trait = "0.1.68"
+displaydoc = "0.2.4"
 
 clap = { version = "4.2.2", optional = true }
 hidapi = { version = "2.1.2", optional = true, default-features = false }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -1,6 +1,6 @@
 //! Ledger interface [Error] type and conversions
 
-use ledger_proto::ApduError;
+use ledger_proto::{ApduError, StatusCode};
 
 /// Ledger interface error type
 #[derive(Debug, thiserror::Error)]
@@ -32,8 +32,13 @@ pub enum Error {
     #[error("Apdu encode/decode error: {0}")]
     Apdu(#[from] ApduError),
 
-    #[error("Response error 0x{0:02x}{1:02x}")]
-    Response(u8, u8),
+    /// Recognised status codes (see [StatusCode])
+    #[error("Status: {0}")]
+    Status(StatusCode),
+
+    /// Unrecognised status codes
+    #[error("Status: 0x{0:02x}{1:02x} (unrecognised)")]
+    UnknownStatus(u8, u8),
 
     #[error("Request timeout")]
     Timeout,

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -12,14 +12,17 @@ license = "Apache-2.0"
 std = [ "dep:thiserror", "alloc" ]
 # `alloc` feature gates `Vec` based types
 alloc = []
+# `serde` feature enables object serialisation and deserialisation
+serde = [ "dep:serde", "dep:hex", "bitflags/serde" ]
 
-default = [ "std" ]
+default = [ "std", "serde" ]
 
 [dependencies]
 encdec = { version = "0.9.0", default_features = false }
 bitflags = { version = "2.1.0", default_features = false }
 displaydoc = { version = "0.2.3", default_features = false }
-serde = { version = "1.0.166", features = ["derive"] }
-hex = { version = "0.4.3", features = ["serde"] }
+num_enum = { version = "0.6.1", default_features = false }
 
+serde = { version = "1.0.166", features = ["derive"], optional = true }
+hex = { version = "0.4.3", features = ["serde"], optional = true }
 thiserror = { version = "1.0.40", optional = true }

--- a/proto/src/apdus/app_info.rs
+++ b/proto/src/apdus/app_info.rs
@@ -102,7 +102,6 @@ impl<'a> Decode<'a> for AppInfoResp<'a> {
 
     fn decode(buff: &'a [u8]) -> Result<(Self::Output, usize), Self::Error> {
         let mut index = 0;
-        let buff = buff;
 
         // Check app version format
         if buff[index] != APP_VERSION_FMT {

--- a/proto/src/apdus/device_info.rs
+++ b/proto/src/apdus/device_info.rs
@@ -101,7 +101,6 @@ impl<'a> Decode<'a> for DeviceInfoResp<'a> {
     /// Decode an device info APDU from the provided buffer
     fn decode(buff: &'a [u8]) -> Result<(Self, usize), ApduError> {
         let mut index = 0;
-        let buff = buff;
 
         // Fetch target id
         let mut target_id = [0u8; 4];

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -107,17 +107,24 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 pub use encdec::{Decode, DecodeOwned, EncDec, Encode};
 
 mod error;
 pub use error::ApduError;
 
-pub use serde::Deserialize;
-
 pub mod apdus;
 
+mod status;
+pub use status::StatusCode;
+
 /// APDU command header
-#[derive(Copy, Clone, PartialEq, Debug, Default, Encode, DecodeOwned, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Encode, DecodeOwned)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[encdec(error = "ApduError")]
 pub struct ApduHeader {
     /// Class ID
@@ -193,13 +200,14 @@ pub trait ApduBase<'a>: EncDec<'a, ApduError> {}
 impl<'a, T: EncDec<'a, ApduError>> ApduBase<'a> for T {}
 
 /// Generic APDU object (enabled with `alloc` feature), prefer use of strict APDU types where possible
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg(feature = "alloc")]
 pub struct GenericApdu {
     /// Request APDU Header (uses [Default] for incoming / response APDUs)
     pub header: ApduHeader,
     /// APDU data
-    #[serde(with = "hex::serde")]
+    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))]
     pub data: Vec<u8>,
 }
 

--- a/proto/src/status.rs
+++ b/proto/src/status.rs
@@ -1,0 +1,85 @@
+/// Device status codes (two bytes, trailing response data)
+///
+/// Replicated from: https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/errors/src/index.ts#L212
+#[derive(Copy, Clone, Debug, displaydoc::Display, num_enum::TryFromPrimitive)]
+#[repr(u16)]
+pub enum StatusCode {
+    /// Access condition not fulfilled
+    AccessConditionNotFulfilled = 0x9804,
+    /// Algorithm not supported
+    AlgorithmNotSupported = 0x9484,
+    /// APDU class not supported
+    ClaNotSupported = 0x6e00,
+    /// Code blocked
+    CodeBlocked = 0x9840,
+    /// Code not initialized
+    CodeNotInitialized = 0x9802,
+    /// Command incompatible file structure
+    CommandIncompatibleFileStructure = 0x6981,
+    /// Conditions of use not satisfied
+    ConditionsOfUseNotSatisfied = 0x6985,
+    /// Contradiction invalidation
+    ContradictionInvalidation = 0x9810,
+    /// Contradiction secret code status
+    ContradictionSecretCodeStatus = 0x9808,
+    /// Custom image bootloader
+    CustomImageBootloader = 0x662f,
+    /// Custom image empty
+    CustomImageEmpty = 0x662e,
+    /// File already exists
+    FileAlreadyExists = 0x6a89,
+    /// File not found
+    FileNotFound = 0x9404,
+    /// GP auth failed
+    GpAuthFailed = 0x6300,
+    /// Device halted
+    Halted = 0x6faa,
+    /// Inconsistent file
+    InconsistentFile = 0x9408,
+    /// Incorrect data
+    IncorrectData = 0x6a80,
+    /// Incorrect length
+    IncorrectLength = 0x6700,
+    /// Incorrect P1 or P2 values
+    IncorrectP1P2 = 0x6b00,
+    /// Instruction not supported
+    InsNotSupported = 0x6d00,
+    /// Device not onboarded
+    DeviceNotOnboarded = 0x6d07,
+    /// Device also not onboarded
+    DeviceNotOnboarded2 = 0x6611,
+    /// Invalid KCV
+    InvalidKcv = 0x9485,
+    /// Invalid offset
+    InvalidOffset = 0x9402,
+    /// Licensing error
+    Licensing = 0x6f42,
+    /// Device locked
+    LockedDevice = 0x5515,
+    /// Max value reached
+    MaxValueReached = 0x9850,
+    /// Memory problem
+    MemoryProblem = 0x9240,
+    /// Missing critical parameter
+    MissingCriticalParameter = 0x6800,
+    /// No EF selected
+    NoEfSelected = 0x9400,
+    /// Not enough memory space
+    NotEnoughMemorySpace = 0x6a84,
+    /// OK
+    Ok = 0x9000,
+    /// Remaining PIN attempts
+    PinRemainingAttempts = 0x63c0,
+    /// Referenced data not found
+    ReferencedDataNotFound = 0x6a88,
+    /// Security status not satisfied
+    SecurityStatusNotSatisfied = 0x6982,
+    /// Technical problem
+    TechnicalProblem = 0x6f00,
+    /// Unknown APDU
+    UnknownApdu = 0x6d02,
+    /// User refused on device
+    UserRefusedOnDevice = 0x5501,
+    /// Not enough space
+    NotEnoughSpace = 0x5102,
+}


### PR DESCRIPTION
adds status codes and matching to the `ledger_lib::Error` type so there are now `Status(StatusCode)` and `UnknownStatus(u8, u8)` variants for recognised and unrecognised status' respectively.

alternately this could be implemented with a `StatusCode::Unknown(u8, u8)` variant which requires a little more boilerplate to implement but means there would only be one `Error::Status` variant, up to y'all whether you have a preference?

(also fixes the `ledger-proto` build for no_std and adds a check for this to CI)

cc. @yhql @yogh333 