### PR TITLE
chore: downgrade some noisy log lines from debug to trace

### DIFF
--- a/lib/src/device.rs
+++ b/lib/src/device.rs
@@ -158,9 +158,12 @@ impl<T: Exchange + Send> Device for T {
         }
 
         // Decode response data - status bytes
+        // NOTE: the `comm.tx`` vs. `comm.tx_length` distinction in io_legacy can
+        // result in some unexpected behaviour when trying to send status bytes.
+        // see: https://github.com/LedgerHQ/ledger-device-rust-sdk/issues/431
         let (resp, _) = RESP::decode(&buff[..n - 2])?;
 
-        debug!("RX: {resp:?}");
+        debug!("RX: {resp:02x?}");
 
         // Return decode response
         Ok(resp)

--- a/lib/src/provider/context.rs
+++ b/lib/src/provider/context.rs
@@ -5,7 +5,7 @@ use tokio::{
     sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     task::LocalSet,
 };
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::{
     error::Error,
@@ -107,10 +107,10 @@ impl ProviderImpl {
 
         // Poll on incoming requests
         while let Some((req, tx)) = self.req_rx.recv().await {
-            debug!("LedgerProvider request: {:02x?}", req);
+            trace!("LedgerProvider request: {:02x?}", req);
 
             if let Some(resp) = self.handle_req(&req).await {
-                debug!("LedgerProvider response: {:02x?}", resp);
+                trace!("LedgerProvider response: {:02x?}", resp);
 
                 if let Err(e) = tx.send(resp) {
                     error!("Failed to forward response: {}", e);

--- a/lib/src/transport/ble.rs
+++ b/lib/src/transport/ble.rs
@@ -100,7 +100,7 @@ impl BleTransport {
                     }
                 };
 
-                debug!("Peripheral: {p:?} props: {properties:?}");
+                trace!("Peripheral: {p:?} props: {properties:?}");
 
                 let Some(model) = properties
                     .services


### PR DESCRIPTION
also adds a note about status bytes where you'll probably end up looking if they're not working (see #431) and makes the `RX`debug line use hex encoding so it's consistent with all the raw log lines.